### PR TITLE
Add "type" attribute to head RSS link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="/css/font-awesome.min.css">
         <link rel="stylesheet" type="text/css" href="/css/syntax.css">
         <link rel="stylesheet" type="text/css" href="/css/base.css">
-        <link rel="alternate" title="RSS" href="https://drewdevault.com/feed.xml">
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="https://drewdevault.com/feed.xml">
         <link rel="icon" type="image/png" href="/avatar.png">
     </head>
     <body>


### PR DESCRIPTION
So that feed readers can detect it automatically.